### PR TITLE
King & Pawn movement is now fixed

### DIFF
--- a/main.py
+++ b/main.py
@@ -8,7 +8,6 @@ from src.board import *
 
 def main():
     
-    
     # Pygame Initialization
     pygame.init()
     screen = pygame.display.set_mode((SCREEN_WIDTH,SCREEN_HEIGHT))
@@ -41,7 +40,11 @@ def main():
                         dragging = True
                         grabbed_piece = square_dict["piece"]
                         grabbed_piece.rect.center = (event.pos[0],event.pos[1]) #snap piece to mouse
-                        possible_moves = grabbed_piece.calc_possible_moves(board_dict_to_array(board), pieces)
+                        
+                        
+                        possible_moves = grabbed_piece.get_possible_moves(board_dict_to_array(board), pieces)
+                        # possible_moves = grabbed_piece.get_legal_moves(board_dict_to_array(board),possible_moves)
+                        
                         print(possible_moves)
                         square_of_origin = square_dict #used to return piece to square in case move is invalid 
                         square_dict["piece"] = None #removes piece from square

--- a/main.py
+++ b/main.py
@@ -41,7 +41,7 @@ def main():
                         grabbed_piece = square_dict["piece"]
                         grabbed_piece.rect.center = (event.pos[0],event.pos[1]) #snap piece to mouse
                         
-                        possible_moves = grabbed_piece.get_possible_moves(board_dict_to_array(board), pieces)
+                        possible_moves = grabbed_piece.get_legal_moves(board_dict_to_array(board), pieces)
                         
                         print(possible_moves)
                         square_of_origin = square_dict #used to return piece to square in case move is invalid 

--- a/main.py
+++ b/main.py
@@ -41,8 +41,7 @@ def main():
                         grabbed_piece = square_dict["piece"]
                         grabbed_piece.rect.center = (event.pos[0],event.pos[1]) #snap piece to mouse
                         
-                        
-                        possible_moves = grabbed_piece.get_legal_moves(board_dict_to_array(board), pieces)
+                        possible_moves = grabbed_piece.get_possible_moves(board_dict_to_array(board), pieces)
                         
                         print(possible_moves)
                         square_of_origin = square_dict #used to return piece to square in case move is invalid 

--- a/main.py
+++ b/main.py
@@ -17,7 +17,7 @@ def main():
     
     # Chess Initialization
     board, pieces = init_pieces(init_board_dict())
-    current_player = Color.WHITE
+    current_player = colour.WHITE
     
     # Game state variables
     dragging = False
@@ -36,14 +36,13 @@ def main():
             if event.type == pygame.MOUSEBUTTONDOWN:
                 for square in board:
                     square_dict = board[square]
-                    if square_dict["piece"] != None and square_dict["piece"].color == current_player and square_dict["piece"].rect.collidepoint(event.pos):
+                    if square_dict["piece"] != None and square_dict["piece"].colour == current_player and square_dict["piece"].rect.collidepoint(event.pos):
                         dragging = True
                         grabbed_piece = square_dict["piece"]
                         grabbed_piece.rect.center = (event.pos[0],event.pos[1]) #snap piece to mouse
                         
                         
-                        possible_moves = grabbed_piece.get_possible_moves(board_dict_to_array(board), pieces)
-                        # possible_moves = grabbed_piece.get_legal_moves(board_dict_to_array(board),possible_moves)
+                        possible_moves = grabbed_piece.get_legal_moves(board_dict_to_array(board), pieces)
                         
                         print(possible_moves)
                         square_of_origin = square_dict #used to return piece to square in case move is invalid 
@@ -63,7 +62,7 @@ def main():
                     if square_rect.collidepoint(event.pos):
                         if square in possible_moves:
                             #check if an enemy piece is on the square and capture it  
-                            if square_content != None and square_content.color != grabbed_piece.color: #capture piece of opposite colour
+                            if square_content != None and square_content.colour != grabbed_piece.colour: #capture piece of opposite colour
                                 pieces = capture_piece(square_content,pieces)
                             grabbed_piece.rect.center = square_rect.center
                             board[square]["piece"] = grabbed_piece #add piece to square onl

--- a/src/board.py
+++ b/src/board.py
@@ -55,7 +55,7 @@ def init_board_dict():
             y = row * CELL_HEIGHT
             square_img_rect = square_img.get_rect(topleft=(x,y))
             
-            board_dict[square_name] = {'index': (row,col), # Used to convert to array to calc_possible_moves
+            board_dict[square_name] = {'index': (row,col), # Used to convert to array to get_possible_moves
                                        'img': square_img, # Used to store sprite to draw to screen
                                        'rect': square_img_rect, # Used to store the square's hitbox
                                        'piece': None # used to store the current piece on the square

--- a/src/board.py
+++ b/src/board.py
@@ -7,29 +7,29 @@ from src.pieces import *
 def init_board_array() -> list:
     board = [[None for _ in range(8)] for _ in range(8)]
     # Queen Q
-    board[name_to_idx("d8")[0]][name_to_idx("d8")[1]] = Queen(Color.BLACK)
-    board[name_to_idx("d1")[0]][name_to_idx("d1")[1]] = Queen(Color.WHITE)
+    board[name_to_idx("d8")[0]][name_to_idx("d8")[1]] = Queen(colour.BLACK)
+    board[name_to_idx("d1")[0]][name_to_idx("d1")[1]] = Queen(colour.WHITE)
     # King K
-    board[name_to_idx("e8")[0]][name_to_idx("e8")[1]] = King(Color.BLACK)
-    board[name_to_idx("e1")[0]][name_to_idx("e1")[1]] = King(Color.WHITE)
+    board[name_to_idx("e8")[0]][name_to_idx("e8")[1]] = King(colour.BLACK)
+    board[name_to_idx("e1")[0]][name_to_idx("e1")[1]] = King(colour.WHITE)
     # Knights N
-    board[name_to_idx("b8")[0]][name_to_idx("b8")[1]] = Knight(Color.BLACK)
-    board[name_to_idx("g8")[0]][name_to_idx("g8")[1]] = Knight(Color.BLACK)
-    board[name_to_idx("b1")[0]][name_to_idx("b1")[1]] = Knight(Color.WHITE)
-    board[name_to_idx("g1")[0]][name_to_idx("g1")[1]] = Knight(Color.WHITE)
+    board[name_to_idx("b8")[0]][name_to_idx("b8")[1]] = Knight(colour.BLACK)
+    board[name_to_idx("g8")[0]][name_to_idx("g8")[1]] = Knight(colour.BLACK)
+    board[name_to_idx("b1")[0]][name_to_idx("b1")[1]] = Knight(colour.WHITE)
+    board[name_to_idx("g1")[0]][name_to_idx("g1")[1]] = Knight(colour.WHITE)
     # Bishop B
-    board[name_to_idx("c8")[0]][name_to_idx("c8")[1]] = Bishop(Color.BLACK)
-    board[name_to_idx("f8")[0]][name_to_idx("f8")[1]] = Bishop(Color.BLACK)
-    board[name_to_idx("c1")[0]][name_to_idx("c1")[1]] = Bishop(Color.WHITE)
-    board[name_to_idx("f1")[0]][name_to_idx("f1")[1]] = Bishop(Color.WHITE)
+    board[name_to_idx("c8")[0]][name_to_idx("c8")[1]] = Bishop(colour.BLACK)
+    board[name_to_idx("f8")[0]][name_to_idx("f8")[1]] = Bishop(colour.BLACK)
+    board[name_to_idx("c1")[0]][name_to_idx("c1")[1]] = Bishop(colour.WHITE)
+    board[name_to_idx("f1")[0]][name_to_idx("f1")[1]] = Bishop(colour.WHITE)
     # Rook R
-    board[name_to_idx("a8")[0]][name_to_idx("a8")[1]] = Rook(Color.BLACK)
-    board[name_to_idx("h8")[0]][name_to_idx("h8")[1]] = Rook(Color.BLACK)
-    board[name_to_idx("a1")[0]][name_to_idx("a1")[1]] = Rook(Color.WHITE)
-    board[name_to_idx("h1")[0]][name_to_idx("h1")[1]] = Rook(Color.WHITE)
+    board[name_to_idx("a8")[0]][name_to_idx("a8")[1]] = Rook(colour.BLACK)
+    board[name_to_idx("h8")[0]][name_to_idx("h8")[1]] = Rook(colour.BLACK)
+    board[name_to_idx("a1")[0]][name_to_idx("a1")[1]] = Rook(colour.WHITE)
+    board[name_to_idx("h1")[0]][name_to_idx("h1")[1]] = Rook(colour.WHITE)
     # Pawns p
-    board[1] = [Pawn(Color.BLACK) for _ in range(len(board[0]))]
-    board[6] = [Pawn(Color.WHITE) for _ in range(len(board[0]))]
+    board[1] = [Pawn(colour.BLACK) for _ in range(len(board[0]))]
+    board[6] = [Pawn(colour.WHITE) for _ in range(len(board[0]))]
     return board
 
 def init_empty_board() -> list:
@@ -76,44 +76,44 @@ def init_pieces(board_dict: dict):
     }
     
     #WHITE PIECES
-    board_dict, pieces_dict = set_piece(Rook, Color.WHITE, "a1", board_dict, pieces_dict)
-    board_dict, pieces_dict = set_piece(Knight, Color.WHITE, "b1", board_dict, pieces_dict)
-    board_dict, pieces_dict = set_piece(Bishop, Color.WHITE, "c1", board_dict, pieces_dict)
-    board_dict, pieces_dict = set_piece(Queen, Color.WHITE, "d1", board_dict, pieces_dict)
-    board_dict, pieces_dict = set_piece(King, Color.WHITE, "e1", board_dict, pieces_dict)
-    board_dict, pieces_dict = set_piece(Bishop, Color.WHITE, "f1", board_dict, pieces_dict)
-    board_dict, pieces_dict = set_piece(Knight, Color.WHITE, "g1", board_dict, pieces_dict)
-    board_dict, pieces_dict = set_piece(Rook, Color.WHITE, "h1", board_dict, pieces_dict)
+    board_dict, pieces_dict = set_piece(Rook, colour.WHITE, "a1", board_dict, pieces_dict)
+    board_dict, pieces_dict = set_piece(Knight, colour.WHITE, "b1", board_dict, pieces_dict)
+    board_dict, pieces_dict = set_piece(Bishop, colour.WHITE, "c1", board_dict, pieces_dict)
+    board_dict, pieces_dict = set_piece(Queen, colour.WHITE, "d1", board_dict, pieces_dict)
+    board_dict, pieces_dict = set_piece(King, colour.WHITE, "e1", board_dict, pieces_dict)
+    board_dict, pieces_dict = set_piece(Bishop, colour.WHITE, "f1", board_dict, pieces_dict)
+    board_dict, pieces_dict = set_piece(Knight, colour.WHITE, "g1", board_dict, pieces_dict)
+    board_dict, pieces_dict = set_piece(Rook, colour.WHITE, "h1", board_dict, pieces_dict)
     
     #BLACK PIECES
-    board_dict, pieces_dict = set_piece(Rook, Color.BLACK, "a8", board_dict, pieces_dict)
-    board_dict, pieces_dict = set_piece(Knight, Color.BLACK, "b8", board_dict, pieces_dict)
-    board_dict, pieces_dict = set_piece(Bishop, Color.BLACK, "c8", board_dict, pieces_dict)
-    board_dict, pieces_dict = set_piece(Queen, Color.BLACK, "d8", board_dict, pieces_dict)
-    board_dict, pieces_dict = set_piece(King, Color.BLACK, "e8", board_dict, pieces_dict)
-    board_dict, pieces_dict = set_piece(Bishop, Color.BLACK, "f8", board_dict, pieces_dict)
-    board_dict, pieces_dict = set_piece(Knight, Color.BLACK, "g8", board_dict, pieces_dict)
-    board_dict, pieces_dict = set_piece(Rook, Color.BLACK, "h8", board_dict, pieces_dict)
+    board_dict, pieces_dict = set_piece(Rook, colour.BLACK, "a8", board_dict, pieces_dict)
+    board_dict, pieces_dict = set_piece(Knight, colour.BLACK, "b8", board_dict, pieces_dict)
+    board_dict, pieces_dict = set_piece(Bishop, colour.BLACK, "c8", board_dict, pieces_dict)
+    board_dict, pieces_dict = set_piece(Queen, colour.BLACK, "d8", board_dict, pieces_dict)
+    board_dict, pieces_dict = set_piece(King, colour.BLACK, "e8", board_dict, pieces_dict)
+    board_dict, pieces_dict = set_piece(Bishop, colour.BLACK, "f8", board_dict, pieces_dict)
+    board_dict, pieces_dict = set_piece(Knight, colour.BLACK, "g8", board_dict, pieces_dict)
+    board_dict, pieces_dict = set_piece(Rook, colour.BLACK, "h8", board_dict, pieces_dict)
     
     #PAWNS
     white_pawn_squares = ["a2","b2","c2","d2","e2","f2","g2","h2"]
     for square in white_pawn_squares:
-        board_dict, pieces_dict = set_piece(Pawn, Color.WHITE, square, board_dict, pieces_dict)
+        board_dict, pieces_dict = set_piece(Pawn, colour.WHITE, square, board_dict, pieces_dict)
     black_pawn_squares = ["a7","b7","c7","d7","e7","f7","g7","h7"]
     for square in black_pawn_squares:
-        board_dict, pieces_dict = set_piece(Pawn, Color.BLACK, square, board_dict, pieces_dict)
+        board_dict, pieces_dict = set_piece(Pawn, colour.BLACK, square, board_dict, pieces_dict)
     
     return board_dict, pieces_dict
 
-def set_piece(new_piece: Piece, color: Color, square: str, board_dict: dict, pieces_dict: dict):
+def set_piece(new_piece: Piece, colour: colour, square: str, board_dict: dict, pieces_dict: dict):
     # Initialize new piece
-    new_piece = new_piece(color,board_dict[square]["rect"])
+    new_piece = new_piece(colour,board_dict[square]["rect"])
     # Update board with new piece at specified square
     board_dict[square]["piece"] = new_piece
     # Update piece dictionary with new piece
-    if color == color.WHITE:
+    if colour == colour.WHITE:
         pieces_dict["active_white"].append(new_piece)
-    elif color == color.BLACK:
+    elif colour == colour.BLACK:
         pieces_dict["active_black"].append(new_piece)
     return board_dict, pieces_dict
     

--- a/src/constants.py
+++ b/src/constants.py
@@ -6,7 +6,7 @@ SPRITE_HEIGHT = SCREEN_HEIGHT / ROWS
 CELL_WIDTH, CELL_HEIGHT = SPRITE_WIDTH, SPRITE_HEIGHT
 
 from enum import Enum
-Color = Enum('Color', ['WHITE', 'BLACK'])
+colour = Enum('colour', ['WHITE', 'BLACK'])
 
 BOARD_REF = [["a8","b8","c8","d8","e8","f8","g8","h8"],
              ["a7","b7","c7","d7","e7","f7","g7","h7"],

--- a/src/move.py
+++ b/src/move.py
@@ -16,8 +16,8 @@ def new_move(board,current_player):
     #check if valid piece for current player
     if piece == None:
         raise Exception("No piece available to move at this location.")
-    if piece.color != current_player:
-        raise Exception("Please chose a piece of your own color")
+    if piece.colour != current_player:
+        raise Exception("Please chose a piece of your own colour")
     
     #debug info
     print(f"Selected: {piece}")

--- a/src/move.py
+++ b/src/move.py
@@ -10,7 +10,7 @@ def new_move(board,current_player):
     old_pos_index = name_to_idx(old_pos_str)
     
     piece = board[old_pos_index[0]][old_pos_index[1]]
-    possible_moves = piece.calc_possible_moves(board)
+    possible_moves = piece.get_possible_moves(board)
     possible_moves = list(map(lambda x: idx_to_name(x),possible_moves))
     
     #check if valid piece for current player

--- a/src/pieces.py
+++ b/src/pieces.py
@@ -26,7 +26,7 @@ class Piece:
     def get_legal_moves(self, board: list, pieces: dict):
         position = self.get_position(board)
         possible_moves = move_search(board, position, self, filtered=True, format='-list')
-        return possible_moves      
+        return possible_moves
 
     
 class Queen(Piece): # can move in any direction => 8 DOF
@@ -141,35 +141,29 @@ class Pawn(Piece): # 1.5 DOF
         #TODO: move diagonally one if it is capturing a piece
         #TODO: en-passant
         position = self.get_position(board)
-        if position[0] == self.starting_row: 
-            self.movedepth = 2 #can move up-two if on starting position
-        else:  
-            self.movedepth = 1 #move up one
+        self.movedepth = 2 if position[0] == self.starting_row else 1
+        possible_moves = move_search(board,position,self,filtered=False,format='-list')
+        return possible_moves
+    
+    def get_legal_moves(self, board: list, pieces: dict):
+        position = self.get_position(board)
+        self.movedepth = 2 if position[0] == self.starting_row else 1
+        possible_moves_dict = move_search(board,position,self,filtered=True,format='-dict')
         
         possible_moves = []
-        possible_moves_dict = move_search(board,position,self,filtered=False,format='-dict')
-        
-        #TODO: since the move depth of pawns is just one we can remove the for loop and
-        #filter moves on vertical 'N' or 'S'
-        for move in possible_moves_dict[self.moveset[0]]: 
-            content = board[name_to_idx(move)[0]][name_to_idx(move)[1]]
-            if content == None:
-                possible_moves.append(move)
-        #filter moves on first diagonal 'NE' or 'SE'
-        for move in possible_moves_dict[self.moveset[1]]:
-            content = board[name_to_idx(move)[0]][name_to_idx(move)[1]]
-            if content != None and content.colour != self.colour:
-                possible_moves.append(move)
-        #filter moves on second diagonal 'NO' or 'SO'
-        for move in possible_moves_dict[self.moveset[2]]:
+        # Add vertical squares to possible moves
+        vertical_moves = possible_moves_dict[self.moveset[0]]
+        possible_moves += vertical_moves
+        # Add diagonal movement only if square is occupied by enemy
+        diagonal_moves = possible_moves_dict[self.moveset[1]] + possible_moves_dict[self.moveset[2]]
+        for move in diagonal_moves:
             content = board[name_to_idx(move)[0]][name_to_idx(move)[1]]
             if content != None and content.colour != self.colour:
                 possible_moves.append(move)
         
         return possible_moves
-    
-    def get_legal_moves(self, board: list, pieces: dict):
-        return self.get_possible_moves(board, pieces)
+        
+        
         
 
 def move_search(board: list, origin: tuple, piece: Piece, filtered: bool=False, format: str='-list'):

--- a/src/pieces.py
+++ b/src/pieces.py
@@ -143,13 +143,23 @@ class Pawn(Piece): # 1.5 DOF
         self.movedepth = 2 if position[0] == self.starting_row else 1
         
         possible_moves_dict = move_search(board,position,self,filtered=True,format='-dict')
-        
         possible_moves_list = []
-        # Add vertical squares to possible moves
+        
+        # Add vertical squares to possible moves if square is empty
         vertical_moves = possible_moves_dict[self.moveset[0]]
-        possible_moves_list += vertical_moves
-        # Add diagonal movement ONLY if square is occupied by enemy
-        diagonal_moves = possible_moves_dict[self.moveset[1]] + possible_moves_dict[self.moveset[2]]
+        for move in vertical_moves:
+            content = board[name_to_idx(move)[0]][name_to_idx(move)[1]]
+            if content == None:
+                possible_moves_list.append(move)
+        
+        # Get the first square of each diagonal <- needed when pawn is on starting rank and has a movedepth of 2
+        diagonal_moves = []
+        for i in [1,2]: # <- these correspond to the indices of the diagonals in self.moveset
+            diagonal_squares = possible_moves_dict[self.moveset[i]]
+            if len(diagonal_squares) != 0:
+                diagonal_moves.append(diagonal_squares[0])
+            
+        # Add square of each diagonal ONLY if square is occupied by enemy        
         for move in diagonal_moves:
             content = board[name_to_idx(move)[0]][name_to_idx(move)[1]]
             if content != None and content.colour != self.colour:

--- a/src/pieces.py
+++ b/src/pieces.py
@@ -1,10 +1,10 @@
-from src.constants import ARRAY_CARDINALS, BOARD_REF, Color
+from src.constants import ARRAY_CARDINALS, BOARD_REF, colour
 from src.sprites import SPRITES_DICT
-from src.utilities import idx_to_name, name_to_idx
+from src.utilities import idx_to_name, name_to_idx, move_dict_to_list
 
 class Piece:
-    def __init__(self, color: Color) -> None:
-        self.color = color
+    def __init__(self, colour: colour) -> None:
+        self.colour = colour
         self.id = None
         self.moveset = None
         self.movedepth = None    
@@ -19,35 +19,37 @@ class Piece:
     # idea: add filter parameter to determine whether user wants to filter or not
     def get_possible_moves(self, board: list, pieces: dict) -> list:
         position = self.get_position(board)
-        possible_moves = cardinal_array_search(position,self.moveset,depth=self.movedepth,mode='-list')
+        possible_moves = move_search(board, position, self, filtered=False, format='-list')
         return possible_moves
     
     # Filter possible moves to take into account board state
-    def get_legal_moves(self, board, possible_moves):
-        pass
-    
+    def get_legal_moves(self, board: list, pieces: dict):
+        position = self.get_position(board)
+        possible_moves = move_search(board, position, self, filtered=True, format='-list')
+        return possible_moves      
+
     
 class Queen(Piece): # can move in any direction => 8 DOF
-    def __init__(self, color: Color, rect) -> None:
-        super().__init__(color)
+    def __init__(self, colour: colour, rect) -> None:
+        super().__init__(colour)
         self.id = "Q"
         self.moveset = ["N","E","S","O","NE","SE","SO","NO"]
-        if color == Color.WHITE:
+        if colour == colour.WHITE:
             self.img = SPRITES_DICT["w_queen"]
-        elif color == Color.BLACK:
+        elif colour == colour.BLACK:
             self.img = SPRITES_DICT["b_queen"]
         self.rect = self.img.get_rect(topleft=(rect.x, rect.y))
         
         
 class King(Piece): # can move to any adjacent square by 1 => 8 DOF
-    def __init__(self, color: Color, rect) -> None:
-        super().__init__(color)
+    def __init__(self, colour: colour, rect) -> None:
+        super().__init__(colour)
         self.id = "K"
         self.moveset = ["N","E","S","O","NE","SE","SO","NO"]
         self.movedepth = 1
-        if color == Color.WHITE:
+        if colour == colour.WHITE:
             self.img = SPRITES_DICT["w_king"]
-        elif color == Color.BLACK:
+        elif colour == colour.BLACK:
             self.img = SPRITES_DICT["b_king"]
         self.rect = self.img.get_rect(topleft=(rect.x, rect.y))
         
@@ -57,7 +59,7 @@ class King(Piece): # can move to any adjacent square by 1 => 8 DOF
     
     def get_possible_moves(self, board: list, pieces: dict) -> list:
         possible_moves = super().get_possible_moves(board,pieces)
-        enemy_moves = get_possible_moves_enemy(board,pieces,self.color)
+        enemy_moves = get_possible_moves_enemy(board,pieces,self.colour)
         filtered_possible_moves = []
         for move in possible_moves:
             if move not in enemy_moves:
@@ -66,13 +68,13 @@ class King(Piece): # can move to any adjacent square by 1 => 8 DOF
         
         
 class Knight(Piece): # can jump in L shape => 8 DOF
-    def __init__(self, color: Color, rect) -> None:
-        super().__init__(color)
+    def __init__(self, colour: colour, rect) -> None:
+        super().__init__(colour)
         self.id = "N"
         self.moveset = [(-2,+1),(-1,+2),(+1,+2),(+2,+1),(+2,-1),(+1,-2),(-1,-2),(-2,-1)]
-        if color == Color.WHITE:
+        if colour == colour.WHITE:
             self.img = SPRITES_DICT["w_knight"]
-        elif color == Color.BLACK:
+        elif colour == colour.BLACK:
             self.img = SPRITES_DICT["b_knight"]
         self.rect = self.img.get_rect(topleft=(rect.x, rect.y))
 
@@ -85,51 +87,54 @@ class Knight(Piece): # can jump in L shape => 8 DOF
             # Check if new_move is within board boundaries
             if 0 <= new_move[0] <= 7 and 0 <= new_move[1] <= 7: 
                 content = board[new_move[0]][new_move[1]]
-                if content != None and content.color != self.color:
+                if content != None and content.colour != self.colour:
                     possible_moves.append(idx_to_name(new_move))
                 elif content == None:
                     possible_moves.append(idx_to_name(new_move))   
         return possible_moves
+    
+    def get_legal_moves(self, board: list, pieces: dict):
+        return self.get_possible_moves(board,pieces)
 
 
 class Bishop(Piece): # can move diagonally => 4 DOF
-    def __init__(self, color: Color, rect) -> None:
-        super().__init__(color)
+    def __init__(self, colour: colour, rect) -> None:
+        super().__init__(colour)
         self.id = "B"
         self.moveset = ["NE","SE","SO","NO"]
-        if color == Color.WHITE:
+        if colour == colour.WHITE:
             self.img = SPRITES_DICT["w_bishop"]
-        elif color == Color.BLACK:
+        elif colour == colour.BLACK:
             self.img = SPRITES_DICT["b_bishop"]
         self.rect = self.img.get_rect(topleft=(rect.x, rect.y))
 
 
 class Rook(Piece): # can move horizontally and vertically => 4 DOF
-    def __init__(self, color: Color, rect) -> None:
-        super().__init__(color)
+    def __init__(self, colour: colour, rect) -> None:
+        super().__init__(colour)
         self.id = "R"
         self.moveset = ["N","E","S","O"]
-        if color == Color.WHITE:
+        if colour == colour.WHITE:
             self.img = SPRITES_DICT["w_rook"]
-        elif color == Color.BLACK:
+        elif colour == colour.BLACK:
             self.img = SPRITES_DICT["b_rook"]
         self.rect = self.img.get_rect(topleft=(rect.x, rect.y))
 
 
 class Pawn(Piece): # 1.5 DOF
-    def __init__(self, color: Color, rect) -> None:
-        super().__init__(color)
+    def __init__(self, colour: colour, rect) -> None:
+        super().__init__(colour)
         self.id = "p"
-        if color == Color.WHITE:
+        if colour == colour.WHITE:
             self.moveset = ["N","NE","NO"]
             self.starting_row = 6
             self.img = SPRITES_DICT["w_pawn"]
-        elif color == Color.BLACK:
+        elif colour == colour.BLACK:
             self.moveset = ["S","SE","SO"]
             self.starting_row = 1
             self.img = SPRITES_DICT["b_pawn"]
         else:
-            raise Exception("Color value should be WHITE or BLACK")
+            raise Exception("colour value should be WHITE or BLACK")
         self.rect = self.img.get_rect(topleft=(rect.x, rect.y))
         
     def get_possible_moves(self, board: list, pieces: dict) -> list:
@@ -137,12 +142,12 @@ class Pawn(Piece): # 1.5 DOF
         #TODO: en-passant
         position = self.get_position(board)
         if position[0] == self.starting_row: 
-            move_depth = 2 #can move up-two if on starting position
+            self.movedepth = 2 #can move up-two if on starting position
         else:  
-            move_depth = 1 #move up one
+            self.movedepth = 1 #move up one
         
         possible_moves = []
-        possible_moves_dict = cardinal_array_search(position,self.moveset,depth=move_depth,mode='-dict')        
+        possible_moves_dict = move_search(board,position,self,filtered=False,format='-dict')
         
         #TODO: since the move depth of pawns is just one we can remove the for loop and
         #filter moves on vertical 'N' or 'S'
@@ -153,78 +158,85 @@ class Pawn(Piece): # 1.5 DOF
         #filter moves on first diagonal 'NE' or 'SE'
         for move in possible_moves_dict[self.moveset[1]]:
             content = board[name_to_idx(move)[0]][name_to_idx(move)[1]]
-            if content != None and content.color != self.color:
+            if content != None and content.colour != self.colour:
                 possible_moves.append(move)
         #filter moves on second diagonal 'NO' or 'SO'
         for move in possible_moves_dict[self.moveset[2]]:
             content = board[name_to_idx(move)[0]][name_to_idx(move)[1]]
-            if content != None and content.color != self.color:
+            if content != None and content.colour != self.colour:
                 possible_moves.append(move)
         
         return possible_moves
+    
+    def get_legal_moves(self, board: list, pieces: dict):
+        return self.get_possible_moves(board, pieces)
         
 
-def cardinal_array_search(origin: tuple, directions: list, depth: int = None, mode: str='-list'):
+def move_search(board: list, origin: tuple, piece: Piece, filtered: bool=False, format: str='-list'):
+    # Get parameters from piece object
+    moveset = piece.moveset
+    depth = piece.movedepth
+    colour = piece.colour
+    
     # Ensure depth is well defined
     if depth == None: depth = len(BOARD_REF) #default to searching whole array
     elif depth < len(BOARD_REF): depth += 1 #+1 because range() excludes the upper bound
     elif depth >= len(BOARD_REF): depth = len(BOARD_REF) #caping the value of depth
 
-    results_dict = {}
-    for direction in directions: #enables multidirectional search    
-        # Initialize cardinal direction key in output dictionary
-        results_dict[direction] = []
+    moves_dict = {}
+    # Search squares in every direction of the piece's moveset
+    for direction in moveset:  
+        # Initialize the direction as a key in the move_dict
+        moves_dict[direction] = []
         
         for i in range(1,depth):
-            # Store the current array position of the search
-            position = ( origin[0] + ARRAY_CARDINALS[direction][0] * i,
-                         origin[1] + ARRAY_CARDINALS[direction][1] * i ) 
+            # Move by 1 element in the current direction
+            search_pos = ( origin[0] + i * ARRAY_CARDINALS[direction][0],
+                           origin[1] + i * ARRAY_CARDINALS[direction][1]) 
             
             # Check if position is within boundaries of BOARD_REF
-            if 0 <= position[0] < len(BOARD_REF) and 0 <= position[1] < len(BOARD_REF): 
+            if 0 <= search_pos[0] < len(BOARD_REF) and 0 <= search_pos[1] < len(BOARD_REF): 
                 # Convert array position to square name (e.g. 'a1', 'g8')
-                result = BOARD_REF[position[0]][position[1]]
-                results_dict[direction].append(result)
+                square = BOARD_REF[search_pos[0]][search_pos[1]]
 
-                #Check if hit a piece
-                # content = board[position[0]][position[1]]
-                # #r = p # to return indices 
-                # #r = board[p[0]][p[1]] # to return board contents
-                # if content != None and content.color == color: #ignore pieces of the same color
-                #     break
-                # elif content != None and content.color != color:
+                if filtered:
+                    # Check content of current square in search
+                    content = board[search_pos[0]][search_pos[1]]
+                    # Stop search in this direction if ENEMY piece is hit and append square to move_dict
+                    if content != None and content.colour != colour:
+                        moves_dict[direction].append(square)
+                        break
+                    # Stop search in this direction if FIRENDLY piece is hit but DO NOT append square to move_dict
+                    elif content != None and content.colour == colour:
+                        break
                     
-                #     results[direction].append(result)
-                #     break
-                # else:
-                #     results[direction].append(result)
+                moves_dict[direction].append(square)
     
-    # Output dictionary if specified
-    if mode == '-dict':
-        return results_dict
-    # Output list as default
+    # Return dictionary if specified
+    if format == '-dict':
+        return moves_dict
+    # Return list as default
+    elif format == '-list':
+        return move_dict_to_list(moves_dict)
     else:
-        results_list = []
-        for direction in results_dict:
-            results_list += results_dict[direction]
-        return results_list
+        raise Exception("move_search: 'format' argument is invalid. Should either be '-dict' or '-list'")
 
 
 def capture_piece(piece,piece_dict):
-    if piece.color == Color.WHITE:
+    if piece.colour == colour.WHITE:
         piece_dict["active_white"].remove(piece)
         piece_dict["captured_white"].append(piece)
-    elif piece.color == Color.BLACK:
+    elif piece.colour == colour.BLACK:
         piece_dict["active_black"].remove(piece)
         piece_dict["captured_black"].append(piece)     
     return piece_dict
 
-def get_possible_moves_enemy(board: list, pieces: dict, piece_color: Color):
+def get_possible_moves_enemy(board: list, pieces: dict, piece_colour: colour):
     # Used by king to identify squares it shouldn't move to
     
-    if piece_color == Color.WHITE:
+    if piece_colour == colour.WHITE:
             enemy_pieces = pieces["active_black"]
-    elif piece_color == Color.BLACK:
+    elif piece_colour == colour.BLACK:
             enemy_pieces = pieces["active_white"]
             
     all_possible_moves = []

--- a/src/pieces.py
+++ b/src/pieces.py
@@ -15,6 +15,7 @@ class Piece:
             if self in board[i]:
                 return (i, board[i].index(self))
 
+    #TODO: remove the need to input the pieces dictionary in get moves methods since it is not needed <- it is only needed for the king
     # Calculate the possible moves for a piece irrespective of board state
     def get_possible_moves(self, board: list, pieces: dict) -> list:
         position = self.get_position(board)
@@ -60,16 +61,13 @@ class King(Piece): # can move to any adjacent square by 1 => 8 DOF
         return super().get_possible_moves(board, pieces)
     
     def get_legal_moves(self, board: list, pieces: dict):
-        possible_moves = super().get_possible_moves(board,pieces)
-        
-        return super().get_legal_moves(board, pieces)
-        # possible_moves = super().get_possible_moves(board,pieces)
-        # enemy_moves = get_possible_moves_enemy(board,pieces,self.colour)
-        # filtered_possible_moves = []
-        # for move in possible_moves:
-        #     if move not in enemy_moves:
-        #         filtered_possible_moves.append(move)
-        # return filtered_possible_moves
+        possible_moves = self.get_possible_moves(board,pieces)
+        enemy_moves = get_possible_moves_enemy(board,pieces,self.colour)
+        legal_moves = []
+        for move in possible_moves:
+            if move not in enemy_moves:
+                legal_moves.append(move)
+        return legal_moves
         
         
 class Knight(Piece): # can jump in L shape => 8 DOF
@@ -159,7 +157,8 @@ class Pawn(Piece): # 1.5 DOF
         diagonals = [1,2] # <- corresponds to indices in self.moveset that are diagonals (e.g. index 1 = 'NE' for white, 'SE' for black)
         for i in diagonals:
             diagonal_moves = possible_moves_dict[self.moveset[i]]
-            possible_moves_list.append(diagonal_moves[0])
+            if len(diagonal_moves) != 0:
+                possible_moves_list.append(diagonal_moves[0])
         
         return possible_moves_list
     
@@ -257,9 +256,6 @@ def get_possible_moves_enemy(board: list, pieces: dict, piece_colour: colour):
             
     all_possible_moves = []
     for piece in enemy_pieces:
-        if type(piece) == King:
-            continue
-        #TODO: fix infinite recursion when enemy king is inccluded
         possible_moves = piece.get_possible_moves(board,pieces)
         all_possible_moves += possible_moves
         

--- a/src/pieces.py
+++ b/src/pieces.py
@@ -142,26 +142,37 @@ class Pawn(Piece): # 1.5 DOF
         #TODO: en-passant
         position = self.get_position(board)
         self.movedepth = 2 if position[0] == self.starting_row else 1
-        possible_moves = move_search(board,position,self,filtered=False,format='-list')
-        return possible_moves
+        possible_moves_dict = move_search(board,position,self,filtered=False,format='-dict')
+        
+        possible_moves_list = []
+        # Add vertical squares to possible moves
+        vertical_moves = possible_moves_dict[self.moveset[0]]
+        possible_moves_list += vertical_moves
+        # Only include first square in diagonals
+        diagonals = [1,2] # <- corresponds to indices in self.moveset that are diagonals (e.g. index 1 = 'NE' for white, 'SE' for black)
+        for i in diagonals:
+            diagonal_moves = possible_moves_dict[self.moveset[i]]
+            possible_moves_list.append(diagonal_moves[0])
+        
+        return possible_moves_list
     
     def get_legal_moves(self, board: list, pieces: dict):
         position = self.get_position(board)
         self.movedepth = 2 if position[0] == self.starting_row else 1
         possible_moves_dict = move_search(board,position,self,filtered=True,format='-dict')
         
-        possible_moves = []
+        possible_moves_list = []
         # Add vertical squares to possible moves
         vertical_moves = possible_moves_dict[self.moveset[0]]
-        possible_moves += vertical_moves
+        possible_moves_list += vertical_moves
         # Add diagonal movement only if square is occupied by enemy
         diagonal_moves = possible_moves_dict[self.moveset[1]] + possible_moves_dict[self.moveset[2]]
         for move in diagonal_moves:
             content = board[name_to_idx(move)[0]][name_to_idx(move)[1]]
             if content != None and content.colour != self.colour:
-                possible_moves.append(move)
+                possible_moves_list.append(move)
         
-        return possible_moves
+        return possible_moves_list
         
         
         

--- a/src/pieces.py
+++ b/src/pieces.py
@@ -61,7 +61,8 @@ class King(Piece): # can move to any adjacent square by 1 => 8 DOF
         return super().get_possible_moves(board, pieces)
     
     def get_legal_moves(self, board: list, pieces: dict):
-        possible_moves = self.get_possible_moves(board,pieces)
+        position = self.get_position(board)
+        possible_moves = move_search(board, position, self, filtered=True, format='-list')
         enemy_moves = get_possible_moves_enemy(board,pieces,self.colour)
         legal_moves = []
         for move in possible_moves:
@@ -254,10 +255,12 @@ def get_possible_moves_enemy(board: list, pieces: dict, piece_colour: colour):
     elif piece_colour == colour.BLACK:
             enemy_pieces = pieces["active_white"]
             
-    all_possible_moves = []
+    possible_moves = []
     for piece in enemy_pieces:
-        possible_moves = piece.get_possible_moves(board,pieces)
-        all_possible_moves += possible_moves
+        if type(piece) == King:
+            possible_moves += piece.get_possible_moves(board,pieces)
+        else:
+            possible_moves += piece.get_legal_moves(board,pieces)
         
-    return list(set(all_possible_moves)) #convert to set to remove duplicate values
+    return list(set(possible_moves)) #convert to set to remove duplicate values
     

--- a/src/sprites.py
+++ b/src/sprites.py
@@ -38,12 +38,10 @@ def load_sprites() -> dict: #returns a dictionary of filepaths
         for filename in sprites_filenames:
             if key in filename:
                 sprite_filepath = os.path.join(sprites_dir,filename)
-                # print(f"{key}: {sprite_filepath}")
                 sprite_image = pygame.image.load(sprite_filepath)
                 #TODO: fix scaling of sprites for the pieces (need to be slightly smaller + something wrong with the look)
                 sprite_image = pygame.transform.scale(sprite_image,(SPRITE_WIDTH,SPRITE_HEIGHT))
                 sprites_dict[key] = sprite_image
-                # print(f"{key}: {sprites_dict[key]}")
                 break
     
     return sprites_dict

--- a/src/utilities.py
+++ b/src/utilities.py
@@ -54,7 +54,8 @@ def update_gamelog(gamelog: dict, turn_number: int, piece, square: str) -> dict:
     
 def board_dict_to_array(board: dict) -> list:
     board_array = [[None for _ in range(8)] for _ in range(8)] #initialize empty board
-    # Could be optimized to not reset the board_array each time calc_possible_moves is called 
+    # Could be optimized to not reset the board_array each time get
+    # _possible_moves is called 
     # but then we would need to maintain two sources of truth: board_dict and board_array
     # I chose to prioritize data integrity before trying to optimize for the time being
     for key in board:

--- a/src/utilities.py
+++ b/src/utilities.py
@@ -45,9 +45,9 @@ def print_gamelog(gamelog) -> None:
 def update_gamelog(gamelog: dict, turn_number: int, piece, square: str) -> dict:
     if piece.id == 'p': id = ''
     else: id = piece.id
-    if piece.color == Color.WHITE:
+    if piece.colour == colour.WHITE:
         gamelog[turn_number] = f"{id}{square}"
-    elif piece.color == Color.BLACK:
+    elif piece.colour == colour.BLACK:
         gamelog[turn_number] += f" {id}{square}"
         turn_number += 1
     return gamelog, turn_number
@@ -66,11 +66,11 @@ def board_dict_to_array(board: dict) -> list:
     
     return board_array
 
-def change_current_player(current_player) -> Color:
-    if current_player == Color.WHITE:
-        return Color.BLACK
-    elif current_player == Color.BLACK:
-        return Color.WHITE
+def change_current_player(current_player) -> colour:
+    if current_player == colour.WHITE:
+        return colour.BLACK
+    elif current_player == colour.BLACK:
+        return colour.WHITE
     
 def clear(): #clears the console line
     # for windows
@@ -79,4 +79,12 @@ def clear(): #clears the console line
     # for mac and linux(here, os.name is 'posix')
     else:
         _ = system('clear')
+        
+def move_dict_to_list(move_dict) -> list:
+    # Concatenates the list stored in each key of a dictionary
+    # Used to convert output of the move_search function from a dictionary to a list
+    moves = []
+    for direction in move_dict:
+        moves += move_dict[direction]
+    return moves
     


### PR DESCRIPTION
Restructured the code so that pieces can return both their legal moves and the squares they are currently threatening.

Implications:
- the King can now properly exclude the squares that are threatened by all other active enemy pieces (Pawns and the enemy King were excluded before)
- all Pawn movements are now possible (except 'en-passant') and return correct values